### PR TITLE
Use alpine as base image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,12 @@
+FROM golang:1.11.4
+WORKDIR /app
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build \
+	-ldflags "-X main.AppVersionMetadata=$(date -u +%s)" \
+	-a -installsuffix cgo -o /go/bin/envtpl ./cmd/envtpl/.
+RUN ./test/test.sh
+
+FROM alpine:3.9.4
+COPY --from=0 /go/bin/envtpl /bin/envtpl
+ENTRYPOINT [ "/bin/envtpl" ]
+


### PR DESCRIPTION
Scratch has some benefits, but it also has one major downside: it is not
compatible with Jenkins pipelines [1], [2]. Their flow requires presense
of `cat` inside the container :)

Resulting image is 12.2MB in size (yeah, a little bigger), but can be
used in Jenkins pipelines.

[1] https://issues.jenkins-ci.org/browse/JENKINS-41316
[2] https://issues.jenkins-ci.org/browse/JENKINS-49278